### PR TITLE
fast pool tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ benchmark.json
 *.log
 *fixture.*.snapshot
 *.CALL_ROLLBACK.snapshot
+*.benchmark.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ typechain-types/
 dist/
 warp_output/
 benchmark.json
+*.log
+*fixture.*.snapshot
+*.CALL_ROLLBACK.snapshot

--- a/contracts/UniswapV3Pool.sol
+++ b/contracts/UniswapV3Pool.sol
@@ -907,10 +907,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
             if (uint128(fees1) > 0) protocolFees.token1 += uint128(fees1);
             feeGrowthGlobal1X128 += FullMath.mulDiv(paid1 - fees1, FixedPoint128.Q128, _liquidity);
         }
-        
-        
-        // emit Flash(msg.sender, recipient, amount0, amount1, paid0, paid1);
-        
+        emit Flash(msg.sender, recipient, amount0, amount1, paid0, paid1);
         }
     }
 

--- a/contracts/UniswapV3PoolDeployer.sol
+++ b/contracts/UniswapV3PoolDeployer.sol
@@ -32,7 +32,7 @@ contract UniswapV3PoolDeployer is IUniswapV3PoolDeployer {
         int24 tickSpacing
     ) internal returns (address pool) {
         parameters = Parameters({factory: factory, token0: token0, token1: token1, fee: fee, tickSpacing: tickSpacing});
-        pool = address(new UniswapV3Pool{salt: keccak256(abi.encode(token0, token1, fee))}());
+        pool = address(new UniswapV3Pool{salt: keccak256(abi.encodePacked(token0, token1, fee))}());
         delete parameters;
     }
 }

--- a/contracts/UniswapV3PoolDeployer.sol
+++ b/contracts/UniswapV3PoolDeployer.sol
@@ -32,7 +32,7 @@ contract UniswapV3PoolDeployer is IUniswapV3PoolDeployer {
         int24 tickSpacing
     ) internal returns (address pool) {
         parameters = Parameters({factory: factory, token0: token0, token1: token1, fee: fee, tickSpacing: tickSpacing});
-        pool = address(new UniswapV3Pool{salt: keccak256(abi.encodePacked(token0, token1, fee))}());
+        pool = address(new UniswapV3Pool{salt: keccak256(abi.encode(token0, token1, fee))}());
         delete parameters;
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,8 @@ import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
 import '@nomiclabs/hardhat-etherscan'
 import 'hardhat-warp'
-// import "@shardlabs/starknet-hardhat-plugin";
+
+const port = (Math.floor(Math.random() * 1000) + 5000).toString()
 
 export default {
   starknet: {
@@ -13,22 +14,22 @@ export default {
   },
   networks: {
     integratedDevnet: {
-      url: "http://127.0.0.1:5050",
+      url: `http://127.0.0.1:${port}`,
 
       // venv: "active" <- for the active virtual environment with installed starknet-devnet
       // venv: "path/to/venv" <- for env with installed starknet-devnet (created with e.g. `python -m venv path/to/venv`)
-      venv: "../warp/venv",
+      venv: "../../starknet-devnet/.env",
 
 
       // optional devnet CLI arguments
-      args: ["--timeout", "10000"],
+      args: ["--seed", "0", "--timeout", "10000"],
 
       // stdout: "logs/stdout.log" <- dumps stdout to the file
-      stdout: "/dev/null", // <- logs stdout to the terminal
+      stdout: "/tmp/logos", // <- logs stdout to the terminal
       // stderr: "logs/stderr.log" <- dumps stderr to the file
       stderr: "STDERR"  // <- logs stderr to the terminal
     },
-  
+
     hardhat: {
       allowUnlimitedContractSize: false,
     },
@@ -85,9 +86,6 @@ export default {
         bytecodeHash: 'none',
       },
     },
-  },
-  paths: {
-    warp: '/Users/jorik/dev/nethermind/warp/bin/warp'
   },
   mocha: {
     timeout: 100000000

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,7 @@ import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
 import '@nomiclabs/hardhat-etherscan'
 import 'hardhat-warp'
-import "@shardlabs/starknet-hardhat-plugin";
+// import "@shardlabs/starknet-hardhat-plugin";
 
 export default {
   starknet: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -25,7 +25,7 @@ export default {
       args: ["--seed", "0", "--timeout", "10000"],
 
       // stdout: "logs/stdout.log" <- dumps stdout to the file
-      stdout: "/tmp/logos", // <- logs stdout to the terminal
+      stdout: `.${port}.log`, // <- logs stdout to the terminal
       // stderr: "logs/stderr.log" <- dumps stderr to the file
       stderr: "STDERR"  // <- logs stderr to the terminal
     },

--- a/test/UniswapV3Factory.spec.ts
+++ b/test/UniswapV3Factory.spec.ts
@@ -1,6 +1,5 @@
 import { Wallet } from 'ethers'
-//@ts-ignore
-import { ethers, waffle, devnet} from 'hardhat'
+import { ethers, waffle } from 'hardhat'
 import { UniswapV3Factory } from '../typechain/UniswapV3Factory'
 import { expect } from './shared/expect'
 import snapshotGasCost from './shared/snapshotGasCost'
@@ -45,15 +44,17 @@ describe('UniswapV3Factory', () => {
     expect(await factory.owner()).to.eq(wallet.address)
   })
 
-  it('factory bytecode size', async () => {
-    expect(((await waffle.provider.getCode(factory.address)).length - 2) / 2).to.matchSnapshot()
-  })
+  // ❌ Reason: Bytecode is different on StarkNet
+  // it('factory bytecode size', async () => {
+  //   expect(((await waffle.provider.getCode(factory.address)).length - 2) / 2).to.matchSnapshot()
+  // })
 
-  it('pool bytecode size', async () => {
-    await factory.createPool(TEST_ADDRESSES[0], TEST_ADDRESSES[1], FeeAmount.MEDIUM)
-    const poolAddress = getCreate2Address(factory.address, TEST_ADDRESSES, FeeAmount.MEDIUM, poolBytecode)
-    expect(((await waffle.provider.getCode(poolAddress)).length - 2) / 2).to.matchSnapshot()
-  })
+  // ❌ Reason: Bytecode is different on StarkNet
+  // it('pool bytecode size', async () => {
+  //   await factory.createPool(TEST_ADDRESSES[0], TEST_ADDRESSES[1], FeeAmount.MEDIUM)
+  //   const poolAddress = getCreate2Address(factory.address, TEST_ADDRESSES, FeeAmount.MEDIUM, poolBytecode)
+  //   expect(((await waffle.provider.getCode(poolAddress)).length - 2) / 2).to.matchSnapshot()
+  // })
 
   it('initial enabled fee amounts', async () => {
     expect(await factory.feeAmountTickSpacing(FeeAmount.LOW)).to.eq(TICK_SPACINGS[FeeAmount.LOW])
@@ -119,9 +120,10 @@ describe('UniswapV3Factory', () => {
       await expect(factory.createPool(TEST_ADDRESSES[0], TEST_ADDRESSES[1], 250)).to.be.reverted
     })
 
-    it('gas', async () => {
-      await snapshotGasCost(factory.createPool(TEST_ADDRESSES[0], TEST_ADDRESSES[1], FeeAmount.MEDIUM))
-    })
+    // ❌ Reason: Gas works differently on StarkNet
+    // it('gas', async () => {
+    //   await snapshotGasCost(factory.createPool(TEST_ADDRESSES[0], TEST_ADDRESSES[1], FeeAmount.MEDIUM))
+    // })
   })
 
   describe('#setOwner', () => {

--- a/test/UniswapV3Factory.spec.ts
+++ b/test/UniswapV3Factory.spec.ts
@@ -1,5 +1,6 @@
 import { Wallet } from 'ethers'
-import { ethers, waffle } from 'hardhat'
+//@ts-ignore
+import { ethers, waffle, devnet} from 'hardhat'
 import { UniswapV3Factory } from '../typechain/UniswapV3Factory'
 import { expect } from './shared/expect'
 import snapshotGasCost from './shared/snapshotGasCost'
@@ -65,27 +66,18 @@ describe('UniswapV3Factory', () => {
     feeAmount: FeeAmount,
     tickSpacing: number = TICK_SPACINGS[feeAmount]
   ) {
-    console.log("entered")
     const create2Address = getCreate2Address(factory.address, tokens, feeAmount, poolBytecode)
     const create = factory.createPool(tokens[0], tokens[1], feeAmount)
-    const rec = await(await create).wait()
-    console.log("events", JSON.stringify(rec.events))
 
-
-    console.log("create2Address",create2Address)
-    console.log("aaaaah")
     await expect(create)
       .to.emit(factory, 'PoolCreated')
       .withArgs(TEST_ADDRESSES[0], TEST_ADDRESSES[1], feeAmount, tickSpacing, create2Address)
 
-    console.log("here")
     await expect(factory.createPool(tokens[0], tokens[1], feeAmount)).to.be.reverted
     await expect(factory.createPool(tokens[1], tokens[0], feeAmount)).to.be.reverted
-    console.log("later")
     expect(await factory.getPool(tokens[0], tokens[1], feeAmount), 'getPool in order').to.eq(create2Address)
     expect(await factory.getPool(tokens[1], tokens[0], feeAmount), 'getPool in reverse').to.eq(create2Address)
 
-    console.log("even later")
     const poolContractFactory = await ethers.getContractFactory('UniswapV3Pool')
     const pool = poolContractFactory.attach(create2Address)
     expect(await pool.factory(), 'pool factory address').to.eq(factory.address)
@@ -96,7 +88,7 @@ describe('UniswapV3Factory', () => {
   }
 
   describe('#createPool', () => {
-    it.only('succeeds for low fee pool', async () => {
+    it('succeeds for low fee pool', async () => {
       await createAndCheckPool(TEST_ADDRESSES, FeeAmount.LOW)
     })
 

--- a/test/UniswapV3Pool.spec.ts
+++ b/test/UniswapV3Pool.spec.ts
@@ -365,12 +365,14 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000)
           })
 
+          // ✅
           it('max tick with max leverage', async () => {
             await mint(wallet.address, maxTick - tickSpacing, maxTick, BigNumber.from(2).pow(102))
             expect(await token0.balanceOf(pool.address)).to.eq(9996 + 828011525)
             expect(await token1.balanceOf(pool.address)).to.eq(1000)
           })
 
+          // ✅
           it('works for max tick', async () => {
             await expect(mint(wallet.address, -22980, maxTick, 10000))
               .to.emit(token0, 'Transfer')
@@ -379,6 +381,7 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000)
           })
 
+          // ❌ Reason: static call doesn't set msg.sender
           it('removing works', async () => {
             await mint(wallet.address, -240, 0, 10000)
             await pool.burn(-240, 0, 10000)
@@ -387,6 +390,7 @@ describe('UniswapV3Pool', () => {
             expect(amount1, 'amount1').to.eq(0)
           })
 
+          // ✅
           it('adds liquidity to liquidityGross', async () => {
             await mint(wallet.address, -240, 0, 100)
             expect((await pool.ticks(-240)).liquidityGross).to.eq(100)
@@ -405,6 +409,7 @@ describe('UniswapV3Pool', () => {
             expect((await pool.ticks(tickSpacing * 2)).liquidityGross).to.eq(60)
           })
 
+          // ✅
           it('removes liquidity from liquidityGross', async () => {
             await mint(wallet.address, -240, 0, 100)
             await mint(wallet.address, -240, 0, 40)
@@ -413,6 +418,7 @@ describe('UniswapV3Pool', () => {
             expect((await pool.ticks(0)).liquidityGross).to.eq(50)
           })
 
+          // ✅
           it('clears tick lower if last position is removed', async () => {
             await mint(wallet.address, -240, 0, 100)
             await pool.burn(-240, 0, 100)
@@ -422,6 +428,7 @@ describe('UniswapV3Pool', () => {
             expect(feeGrowthOutside1X128).to.eq(0)
           })
 
+          // ✅
           it('clears tick upper if last position is removed', async () => {
             await mint(wallet.address, -240, 0, 100)
             await pool.burn(-240, 0, 100)
@@ -430,6 +437,7 @@ describe('UniswapV3Pool', () => {
             expect(feeGrowthOutside0X128).to.eq(0)
             expect(feeGrowthOutside1X128).to.eq(0)
           })
+          // ✅
           it('only clears the tick that is not used at all', async () => {
             await mint(wallet.address, -240, 0, 100)
             await mint(wallet.address, -tickSpacing, 0, 250)
@@ -444,7 +452,7 @@ describe('UniswapV3Pool', () => {
             expect(feeGrowthOutside0X128).to.eq(0)
             expect(feeGrowthOutside1X128).to.eq(0)
           })
-
+          // ✅
           it('does not write an observation', async () => {
             checkObservationEquals(await pool.observations(0), {
               tickCumulative: 0,
@@ -464,6 +472,7 @@ describe('UniswapV3Pool', () => {
         })
 
         describe('including current price', () => {
+          // ✅
           it('price within range: transfers current price of both tokens', async () => {
             await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100))
               .to.emit(token0, 'Transfer')
@@ -474,18 +483,21 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 32)
           })
 
+          // ✅
           it('initializes lower tick', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100)
             const { liquidityGross } = await pool.ticks(minTick + tickSpacing)
             expect(liquidityGross).to.eq(100)
           })
 
+          // ✅
           it('initializes upper tick', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100)
             const { liquidityGross } = await pool.ticks(maxTick - tickSpacing)
             expect(liquidityGross).to.eq(100)
           })
 
+          // ✅
           it('works for min/max tick', async () => {
             await expect(mint(wallet.address, minTick, maxTick, 10000))
               .to.emit(token0, 'Transfer')
@@ -496,6 +508,7 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 3163)
           })
 
+          // ❌ Reason: static call doesn't set msg.sender
           it('removing works', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100)
             await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 100)
@@ -510,6 +523,7 @@ describe('UniswapV3Pool', () => {
             expect(amount1, 'amount1').to.eq(31)
           })
 
+          // ✅
           it('writes an observation', async () => {
             checkObservationEquals(await pool.observations(0), {
               tickCumulative: 0,
@@ -529,6 +543,7 @@ describe('UniswapV3Pool', () => {
         })
 
         describe('below current price', () => {
+          // ✅
           it('transfers token1 only', async () => {
             await expect(mint(wallet.address, -46080, -23040, 10000))
               .to.emit(token1, 'Transfer')
@@ -538,12 +553,14 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 2162)
           })
 
+          // ✅
           it('min tick with max leverage', async () => {
             await mint(wallet.address, minTick, minTick + tickSpacing, BigNumber.from(2).pow(102))
             expect(await token0.balanceOf(pool.address)).to.eq(9996)
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 828011520)
           })
 
+          // ✅
           it('works for min tick', async () => {
             await expect(mint(wallet.address, minTick, -23040, 10000))
               .to.emit(token1, 'Transfer')
@@ -552,6 +569,7 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 3161)
           })
 
+          // ❌ Reason: static call doesn't set msg.sender
           it('removing works', async () => {
             await mint(wallet.address, -46080, -46020, 10000)
             await pool.burn(-46080, -46020, 10000)

--- a/test/UniswapV3Pool.spec.ts
+++ b/test/UniswapV3Pool.spec.ts
@@ -282,7 +282,7 @@ describe('UniswapV3Pool', () => {
     })
   })
 
-  describe.only('#mint', () => {
+  describe('#mint', () => {
     // ✅
     it('fails if not initialized', async () => {
       await expect(mint(wallet.address, -tickSpacing, tickSpacing, 1)).to.be.revertedWith('LOK')
@@ -382,7 +382,7 @@ describe('UniswapV3Pool', () => {
           })
 
           // ❌ Reason: static call doesn't set msg.sender
-          it('removing works', async () => {
+          it.only('removing works', async () => {
             await mint(wallet.address, -240, 0, 10000)
             await pool.burn(-240, 0, 10000)
             const { amount0, amount1 } = await pool.callStatic.collect(wallet.address, -240, 0, MaxUint128, MaxUint128)
@@ -509,7 +509,7 @@ describe('UniswapV3Pool', () => {
           })
 
           // ❌ Reason: static call doesn't set msg.sender
-          it('removing works', async () => {
+          it.only('removing works', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100)
             await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 100)
             const { amount0, amount1 } = await pool.callStatic.collect(
@@ -570,7 +570,7 @@ describe('UniswapV3Pool', () => {
           })
 
           // ❌ Reason: static call doesn't set msg.sender
-          it('removing works', async () => {
+          it.only('removing works', async () => {
             await mint(wallet.address, -46080, -46020, 10000)
             await pool.burn(-46080, -46020, 10000)
             const { amount0, amount1 } = await pool.callStatic.collect(
@@ -632,7 +632,7 @@ describe('UniswapV3Pool', () => {
         expect(token1ProtocolFees).to.eq(0)
       })
 
-      // ❌
+      // ✅
       it('poke is not allowed on uninitialized position', async () => {
         await mint(other.address, minTick + tickSpacing, maxTick - tickSpacing, expandTo18Decimals(1))
         await swapExact0For1(expandTo18Decimals(1).div(10), wallet.address)

--- a/test/UniswapV3Pool.spec.ts
+++ b/test/UniswapV3Pool.spec.ts
@@ -382,7 +382,7 @@ describe('UniswapV3Pool', () => {
           })
 
           // ❌ Reason: static call doesn't set msg.sender
-          it.only('removing works', async () => {
+          it('removing works', async () => {
             await mint(wallet.address, -240, 0, 10000)
             await pool.burn(-240, 0, 10000)
             const { amount0, amount1 } = await pool.callStatic.collect(wallet.address, -240, 0, MaxUint128, MaxUint128)
@@ -509,7 +509,7 @@ describe('UniswapV3Pool', () => {
           })
 
           // ❌ Reason: static call doesn't set msg.sender
-          it.only('removing works', async () => {
+          it('removing works', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100)
             await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 100)
             const { amount0, amount1 } = await pool.callStatic.collect(
@@ -570,7 +570,7 @@ describe('UniswapV3Pool', () => {
           })
 
           // ❌ Reason: static call doesn't set msg.sender
-          it.only('removing works', async () => {
+          it('removing works', async () => {
             await mint(wallet.address, -46080, -46020, 10000)
             await pool.burn(-46080, -46020, 10000)
             const { amount0, amount1 } = await pool.callStatic.collect(
@@ -804,6 +804,7 @@ describe('UniswapV3Pool', () => {
       await initializeAtZeroTick(pool)
     })
 
+    // ✅
     it('mint to the right of the current price', async () => {
       const liquidityDelta = 1000
       const lowerTick = tickSpacing
@@ -1068,6 +1069,7 @@ describe('UniswapV3Pool', () => {
       await pool.initialize(encodePriceSqrt(1, 1))
     })
 
+    // ✅
     it('works with multiple LPs', async () => {
       await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))
       await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, expandTo18Decimals(2))
@@ -1458,6 +1460,7 @@ describe('UniswapV3Pool', () => {
             .to.not.emit(token1, 'Transfer')
           expect((await pool.slot0()).tick).to.eq(120196)
         })
+        // ✅
         it('swapping across gaps works in 0 for 1 direction', async () => {
           const liquidityAmount = expandTo18Decimals(1).div(4)
           await mint(wallet.address, -121200, -120000, liquidityAmount)

--- a/test/UniswapV3Pool.spec.ts
+++ b/test/UniswapV3Pool.spec.ts
@@ -74,98 +74,10 @@ describe('UniswapV3Pool', () => {
   })
 
   beforeEach('deploy fixture', async () => {
-    // console.log("before fixture")
-    // ;({ token0, token1, token2, factory, createPool, swapTargetCallee: swapTarget } = await loadFixture(poolFixture))
-    // console.log({token0: token0.address})
-    // console.log({token1: token1.address})
-    // console.log({token2: token2.address})
-    // console.log({factory: factory.address})
-    // console.log({swapTargetCallee: swapTarget.address})
-    // const oldCreatePool = createPool
-    // createPool = async (_feeAmount, _tickSpacing) => {
-    //   const pool = await oldCreatePool(_feeAmount, _tickSpacing)
-    //   ;({
-    //     swapToLowerPrice,
-    //     swapToHigherPrice,
-    //     swapExact0For1,
-    //     swap0ForExact1,
-    //     swapExact1For0,
-    //     swap1ForExact0,
-    //     mint,
-    //     flash,
-    //   } = createPoolFunctions({
-    //     token0,
-    //     token1,
-    //     swapTarget,
-    //     pool,
-    //   }))
-    //   minTick = getMinTick(_tickSpacing)
-    //   maxTick = getMaxTick(_tickSpacing)
-    //   feeAmount = _feeAmount
-    //   tickSpacing = _tickSpacing
-    //   return pool
-    // }
-
-    // // default to the 30 bips pool
-    // pool = await createPool(FeeAmount.MEDIUM, TICK_SPACINGS[FeeAmount.MEDIUM])
-    // console.log({adddress: pool.address})
-    // devnet.dump("cocaine");
-    // console.log("dump complete")
-    // throw new Error("We're out boyos")
-
-
-
-
-    await devnet.load("cocaine");
-    // await new Promise(r => setTimeout(r, 400));
-    minTick = getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM])
-    maxTick = getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM])
-    feeAmount = FeeAmount.MEDIUM
-    tickSpacing = TICK_SPACINGS[FeeAmount.MEDIUM];
-    const MockTimeUniswapV3PoolDeployerFactory = await ethers.getContractFactory('MockTimeUniswapV3PoolDeployer')
-    const poolDeployer = MockTimeUniswapV3PoolDeployerFactory.attach("0x037a297229680497db895b1c58e64d2123c68d8f7b91d085f2e9bc64a071e35a") as MockTimeUniswapV3PoolDeployer;
-    const TestERC20Factory = await ethers.getContractFactory('TestERC20')
-    token0 = TestERC20Factory.attach("0x00cc4ffc5b214d0526f1a52d2ab847b4a1991dbd573a3fe08082236ca7445142") as TestERC20;
-    token1 = TestERC20Factory.attach("0x034d5975e0b15dedcba7db3663cc3933b68b6d71eded1f12a7f4124a5c2c6e3d") as TestERC20;
-    token2 = TestERC20Factory.attach("0x043fc20df5a51dfe77978f39a92bf30956ab1791e52632cbb7319d38ba274e66") as TestERC20;
-    const FactoryFactory = await ethers.getContractFactory("UniswapV3Factory");
-    factory = FactoryFactory.attach("0x05beeb39aa24e15a8f94a2c42eaa0f20ef32610bc176673c4ec6512a171c4403") as UniswapV3Factory;
-    const calleeContractFactory = await ethers.getContractFactory('TestUniswapV3Callee')
-    swapTarget = calleeContractFactory.attach("0x0476d99634da83bbafc93f88eb16df19651244d2ec5e55d114a0361ac2d9927a") as TestUniswapV3Callee;
-    const MockTimeUniswapV3PoolFactory = await ethers.getContractFactory('MockTimeUniswapV3Pool')
-    pool = MockTimeUniswapV3PoolFactory.attach("0x01299e338a4ea46a0ce974a7b1a3c3642d16f55e509c3e887e80d78b5093adde") as MockTimeUniswapV3Pool
-    ;({
-        swapToLowerPrice,
-        swapToHigherPrice,
-        swapExact0For1,
-        swap0ForExact1,
-        swapExact1For0,
-        swap1ForExact0,
-        mint,
-        flash,
-      } = createPoolFunctions({
-        token0,
-        token1,
-        swapTarget,
-        pool,
-      }))
+    ;({ token0, token1, token2, factory, createPool, swapTargetCallee: swapTarget } = await loadFixture(poolFixture))
+    const oldCreatePool = createPool
     createPool = async (_feeAmount, _tickSpacing) => {
-      const mockTimePoolDeployer = (await MockTimeUniswapV3PoolDeployerFactory.deploy()) as MockTimeUniswapV3PoolDeployer
-      const tx = await mockTimePoolDeployer.deploy(
-        factory.address,
-        token0.address,
-        token0.address,
-        _feeAmount,
-        _tickSpacing
-      )
-
-      const receipt = await tx.wait()
-      const poolAddress = receipt.events?.[0].args?.pool as string
-      let pool_ =  MockTimeUniswapV3PoolFactory.attach(poolAddress) as MockTimeUniswapV3Pool
-      minTick = getMinTick(_tickSpacing)
-      maxTick = getMaxTick(_tickSpacing)
-      feeAmount = _feeAmount
-      tickSpacing = _tickSpacing
+      const pool = await oldCreatePool(_feeAmount, _tickSpacing)
       ;({
         swapToLowerPrice,
         swapToHigherPrice,
@@ -181,9 +93,15 @@ describe('UniswapV3Pool', () => {
         swapTarget,
         pool,
       }))
-      return pool_;
+      minTick = getMinTick(_tickSpacing)
+      maxTick = getMaxTick(_tickSpacing)
+      feeAmount = _feeAmount
+      tickSpacing = _tickSpacing
+      return pool
     }
 
+    // default to the 30 bips pool
+    pool = await createPool(FeeAmount.MEDIUM, TICK_SPACINGS[FeeAmount.MEDIUM])
   })
 
   // ✅
@@ -381,7 +299,7 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000)
           })
 
-          // ❌ Reason: static call doesn't set msg.sender
+          // ✅
           it('removing works', async () => {
             await mint(wallet.address, -240, 0, 10000)
             await pool.burn(-240, 0, 10000)
@@ -508,7 +426,7 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 3163)
           })
 
-          // ❌ Reason: static call doesn't set msg.sender
+          // ✅
           it('removing works', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100)
             await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 100)
@@ -569,7 +487,7 @@ describe('UniswapV3Pool', () => {
             expect(await token1.balanceOf(pool.address)).to.eq(1000 + 3161)
           })
 
-          // ❌ Reason: static call doesn't set msg.sender
+          // ✅
           it('removing works', async () => {
             await mint(wallet.address, -46080, -46020, 10000)
             await pool.burn(-46080, -46020, 10000)

--- a/test/UniswapV3Pool.spec.ts
+++ b/test/UniswapV3Pool.spec.ts
@@ -318,6 +318,7 @@ describe('UniswapV3Pool', () => {
           await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross)).to.not.be
             .reverted
         })
+        // ✅
         it('fails if total amount at tick exceeds the max', async () => {
           // these should fail with 'LO' but hardhat is bugged
           await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000)
@@ -335,22 +336,26 @@ describe('UniswapV3Pool', () => {
           await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.sub(1000)))
             .to.not.be.reverted
         })
+        // ✅
         it('fails if amount is 0', async () => {
           await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 0)).to.be.reverted
         })
       })
 
       describe('success cases', () => {
+        // ✅
         it('initial balances', async () => {
           expect(await token0.balanceOf(pool.address)).to.eq(9996)
           expect(await token1.balanceOf(pool.address)).to.eq(1000)
         })
 
+        // ✅
         it('initial tick', async () => {
           expect((await pool.slot0()).tick).to.eq(-23028)
         })
 
         describe('above current price', () => {
+          // ✅
           it('transfers token0 only', async () => {
             await expect(mint(wallet.address, -22980, 0, 10000))
               .to.emit(token0, 'Transfer')

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -76,7 +76,6 @@ export const poolFixture: Fixture<PoolFixture> = async function (): Promise<Pool
     swapTargetRouter,
     createPool: async (fee, tickSpacing, firstToken = token0, secondToken = token1) => {
       const mockTimePoolDeployer = (await MockTimeUniswapV3PoolDeployerFactory.deploy()) as MockTimeUniswapV3PoolDeployer
-      console.log({deployer: mockTimePoolDeployer.address})
       const tx = await mockTimePoolDeployer.deploy(
         factory.address,
         firstToken.address,

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -76,6 +76,7 @@ export const poolFixture: Fixture<PoolFixture> = async function (): Promise<Pool
     swapTargetRouter,
     createPool: async (fee, tickSpacing, firstToken = token0, secondToken = token1) => {
       const mockTimePoolDeployer = (await MockTimeUniswapV3PoolDeployerFactory.deploy()) as MockTimeUniswapV3PoolDeployer
+      console.log({deployer: mockTimePoolDeployer.address})
       const tx = await mockTimePoolDeployer.deploy(
         factory.address,
         firstToken.address,
@@ -90,3 +91,4 @@ export const poolFixture: Fixture<PoolFixture> = async function (): Promise<Pool
     },
   }
 }
+

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -45,7 +45,7 @@ export function getCreate2Address(
   const [token0, token1] = tokenA.toLowerCase() < tokenB.toLowerCase() ? [tokenA, tokenB] : [tokenB, tokenA]
 
   const args = [BigInt(token0).toString(16).padStart(64, '0'), BigInt(token1).toString(16).padStart(64, '0'),
-  BigInt(fee).toString(16).padStart(6, '0')].join('');
+  BigInt(fee).toString(16).padStart(64, '0')].join('');
 
   const salt = utils.keccak256(`0x${args}`).slice(0,-4)
 


### PR DESCRIPTION
- Fast testing
- Mark working tests so far
- Update mint test status
- abiecodePacked in PoolDeployer
- Back to OG abi.encode
- Random port every run
- Write all logs to the same file
- Ignore logs and snapshots
- bring back flash event
- Cleanup factory
- Update ticks
- Add failing reason in factory tests
- Gitignore, update test results, revert pool creation
